### PR TITLE
[BUGFIX] Modification de la date par défaut dans le dashboard Sitespeed

### DIFF
--- a/grafana-provisioning/dashboards/page_metrics_dashboard.json
+++ b/grafana-provisioning/dashboards/page_metrics_dashboard.json
@@ -24,15 +24,11 @@
         "limit": 100,
         "name": "sitespeed.io",
         "showIn": 0,
-        "tags": [
-          "sitespeed.io"
-        ],
+        "tags": ["sitespeed.io"],
         "target": {
           "limit": 100,
           "matchAny": false,
-          "tags": [
-            "sitespeed.io"
-          ],
+          "tags": ["sitespeed.io"],
           "type": "tags"
         },
         "type": "tags"
@@ -45,9 +41,7 @@
         "target": {
           "limit": 100,
           "matchAny": true,
-          "tags": [
-            "alert"
-          ],
+          "tags": ["alert"],
           "type": "tags"
         }
       }
@@ -173,12 +167,7 @@
           "links": [],
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max",
-                "lastNotNull",
-                "range"
-              ],
+              "calcs": ["min", "max", "lastNotNull", "range"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -318,9 +307,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -398,9 +385,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -478,9 +463,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -580,9 +563,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -660,9 +641,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -740,9 +719,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -820,9 +797,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -923,9 +898,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -1003,9 +976,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -1083,9 +1054,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -1163,9 +1132,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -1266,9 +1233,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -1346,9 +1311,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -1426,9 +1389,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -1506,9 +1467,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -1611,10 +1570,7 @@
           "links": [],
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max"
-              ],
+              "calcs": ["min", "max"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -1714,10 +1670,7 @@
           "links": [],
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max"
-              ],
+              "calcs": ["min", "max"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -1817,10 +1770,7 @@
           "links": [],
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max"
-              ],
+              "calcs": ["min", "max"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -1920,10 +1870,7 @@
           "links": [],
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max"
-              ],
+              "calcs": ["min", "max"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -1985,15 +1932,11 @@
               "calcs": [],
               "displayMode": "table",
               "placement": "right",
-              "values": [
-                "value"
-              ]
+              "values": ["value"]
             },
             "pieType": "pie",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -2055,15 +1998,11 @@
               "calcs": [],
               "displayMode": "table",
               "placement": "right",
-              "values": [
-                "value"
-              ]
+              "values": ["value"]
             },
             "pieType": "pie",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -2219,10 +2158,7 @@
           "maxDataPoints": 100,
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max"
-              ],
+              "calcs": ["min", "max"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -2328,10 +2264,7 @@
           "maxDataPoints": 100,
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max"
-              ],
+              "calcs": ["min", "max"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -2459,11 +2392,7 @@
           ],
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max",
-                "lastNotNull"
-              ],
+              "calcs": ["min", "max", "lastNotNull"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -2577,11 +2506,7 @@
           ],
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max",
-                "lastNotNull"
-              ],
+              "calcs": ["min", "max", "lastNotNull"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -2695,11 +2620,7 @@
           ],
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max",
-                "lastNotNull"
-              ],
+              "calcs": ["min", "max", "lastNotNull"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -2813,11 +2734,7 @@
           ],
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max",
-                "lastNotNull"
-              ],
+              "calcs": ["min", "max", "lastNotNull"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -3297,11 +3214,7 @@
           "links": [],
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max",
-                "lastNotNull"
-              ],
+              "calcs": ["min", "max", "lastNotNull"],
               "displayMode": "table",
               "placement": "right"
             },
@@ -3376,9 +3289,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -3448,9 +3359,7 @@
             "justifyMode": "center",
             "orientation": "horizontal",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -3520,9 +3429,7 @@
             "justifyMode": "center",
             "orientation": "horizontal",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -3592,9 +3499,7 @@
             "justifyMode": "center",
             "orientation": "horizontal",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -3664,9 +3569,7 @@
             "justifyMode": "center",
             "orientation": "horizontal",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -3737,9 +3640,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -3809,9 +3710,7 @@
             "justifyMode": "center",
             "orientation": "horizontal",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -3881,9 +3780,7 @@
             "justifyMode": "center",
             "orientation": "horizontal",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -3953,9 +3850,7 @@
             "justifyMode": "center",
             "orientation": "horizontal",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -4045,9 +3940,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -4119,9 +4012,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -4197,9 +4088,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -4275,9 +4164,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -4367,10 +4254,7 @@
           "maxDataPoints": 100,
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max"
-              ],
+              "calcs": ["min", "max"],
               "displayMode": "list",
               "placement": "bottom"
             },
@@ -4462,10 +4346,7 @@
           "maxDataPoints": 100,
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max"
-              ],
+              "calcs": ["min", "max"],
               "displayMode": "list",
               "placement": "bottom"
             },
@@ -4556,10 +4437,7 @@
           "maxDataPoints": 100,
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max"
-              ],
+              "calcs": ["min", "max"],
               "displayMode": "list",
               "placement": "bottom"
             },
@@ -4650,10 +4528,7 @@
           "maxDataPoints": 100,
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max"
-              ],
+              "calcs": ["min", "max"],
               "displayMode": "list",
               "placement": "bottom"
             },
@@ -4748,9 +4623,7 @@
             "justifyMode": "center",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -4853,11 +4726,7 @@
           "links": [],
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max",
-                "lastNotNull"
-              ],
+              "calcs": ["min", "max", "lastNotNull"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -4963,12 +4832,7 @@
           "links": [],
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max",
-                "lastNotNull",
-                "range"
-              ],
+              "calcs": ["min", "max", "lastNotNull", "range"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -5068,9 +4932,7 @@
                   "id": "byNames",
                   "options": {
                     "mode": "exclude",
-                    "names": [
-                      "firstParty"
-                    ],
+                    "names": ["firstParty"],
                     "prefix": "All except:",
                     "readOnly": true
                   }
@@ -5099,10 +4961,7 @@
           "maxDataPoints": 100,
           "options": {
             "legend": {
-              "calcs": [
-                "min",
-                "max"
-              ],
+              "calcs": ["min", "max"],
               "displayMode": "table",
               "placement": "bottom"
             },
@@ -5294,8 +5153,8 @@
     ]
   },
   "time": {
-    "from": "2022-07-22T22:11:52.768Z",
-    "to": "2022-09-24T22:11:52.832Z"
+    "from": "now-7d",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -5310,17 +5169,7 @@
       "2h",
       "1d"
     ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
   },
   "timezone": "browser",
   "title": "Sitespeed page metrics",


### PR DESCRIPTION
## ❌ Problème

Sur Grafana, lorsqu'on se rend sur le dashboard **Sitespeed**, nous sommes forcés de modifier la date par défaut afin d'apercevoir nos nouvelles metrics.

## 🎁 Proposition

Modification des valeurs par défaut : **J-7 jusqu'à Jour-J**

## 🌈 Remarques

RAS

## 💯 Pour tester

- Avoir votre container **Grafana qui tourne** 
- Accéder à Grafana, s'il tourne sur le port 3000 en local (par défaut), alors se rendre sur : `http://localhost:3000/` 
- Cliquer sur le dashboard de **Sitespeed** 
- La plage des dates devrait alors correspondre à : **J-7 à Jour-J**
