### PR TITLE
[Feature] Implemented Export to CSV

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: influxdb
     restart: always
     ports:
-      - '8086:8086'
+      - "8086:8086"
     volumes:
       - influxdb-storage:/var/lib/influxdb2
       - ./influxdb/queries:/home/queries:rw
@@ -17,9 +17,9 @@ services:
       - DOCKER_INFLUXDB_INIT_ORG=${INFLUXDB_ORG_NAME}
       - DOCKER_INFLUXDB_INIT_BUCKET=${INFLUXDB_BUCKET_NAME}
       - DOCKER_INFLUXDB_INIT_RETENTION=${INFLUXDB_RETENTION}
-    networks: 
-     - pagiel
-      
+    networks:
+      - pagiel
+
   powerapi-hwpc-sensor:
     image: ${POWER_API_HWPC_SENSOR_IMAGE_VERSION}
     container_name: powerapi-hwpc-sensor
@@ -32,8 +32,8 @@ services:
     command: --config-file /config.json
     profiles:
       - preconso
-    networks: 
-     - pagiel
+    networks:
+      - pagiel
 
   smartwatts:
     image: ${SMARTWATTS_IMAGE_VERSION}
@@ -46,22 +46,22 @@ services:
       - preconso
     volumes:
       - ./smartwatts/config.json:/config.json:ro
-    networks: 
-     - pagiel
+    networks:
+      - pagiel
 
   selenium-hub:
     image: ${SELENIUM_HUB_IMAGE_VERSION}
     container_name: selenium-hub
     expose:
-      - 4444    
+      - 4444
     ports:
       - "4442:4442"
       - "4443:4443"
       - "4444:4444"
     profiles:
       - preconso
-    networks: 
-     - pagiel
+    networks:
+      - pagiel
 
   chrome:
     image: ${SELENIUM_NODE_CHROME_IMAGE_VERSION}
@@ -78,8 +78,8 @@ services:
       - "6900:5900"
     profiles:
       - preconso
-    networks: 
-     - pagiel
+    networks:
+      - pagiel
 
   robot-chrome-test:
     image: ${ROBOT_IMAGE_VERSION}
@@ -90,8 +90,8 @@ services:
       - ./robot-results/gc:/out:rw
     profiles:
       - conso
-    networks: 
-     - pagiel
+    networks:
+      - pagiel
 
   eco-index:
     image: ${GREENIT_ANALYSIS_IMAGE_VERSION}
@@ -106,13 +106,13 @@ services:
       - TZ:Europe/Paris
     profiles:
       - test
-    networks: 
-     - pagiel
+    networks:
+      - pagiel
 
   sitespeed:
     container_name: sitespeed
     image: ${SITESPEED_IMAGE_VERSION}
-    shm_size: '1g'
+    shm_size: "1g"
     depends_on:
       - influxdb
     command: --config /sitespeed.io/config.json /input/urls.txt
@@ -122,9 +122,9 @@ services:
       - ./sitespeed/config/config.json:/sitespeed.io/config.json
     profiles:
       - test
-    networks: 
-     - pagiel
-  
+    networks:
+      - pagiel
+
   yellowlabtools:
     container_name: yellowlabtools
     image: ${YELLOWLABTOOLS_IMAGE_VERSION}
@@ -138,15 +138,15 @@ services:
     privileged: true
     profiles:
       - test
-    networks: 
-     - pagiel
+    networks:
+      - pagiel
 
   grafana:
     container_name: grafana
     image: ${GRAFANA_IMAGE_VERSION}
     restart: always
     ports:
-      - '3000:3000'
+      - "3000:3000"
     volumes:
       - grafana-storage:/var/lib/grafana
       - ./grafana-provisioning/:/etc/grafana/provisioning
@@ -165,26 +165,26 @@ services:
       - INFLUXDB_PORT=${INFLUXDB_PORT}
     profiles:
       - display
-    networks: 
-     - pagiel
-  
+    networks:
+      - pagiel
+
   url-converter:
     container_name: url-converter
     image: ${URL_CONVERTER_IMAGE_VERSION}
     command: /home/urlconverter/urls.yaml
-    volumes: 
+    volumes:
       - ./input/urls.yaml:/home/urlconverter/urls.yaml:ro
       - tmp-storage:/home/urlconverter/results:rw
       - ./input/templates/:/home/urlconverter/templates/:ro
       - ./robot/tests/:/home/urlconverter/tests/:rw
     profiles:
       - pretest
-    networks: 
-     - pagiel
+    networks:
+      - pagiel
 
   report:
     container_name: report
-    image: ${REPORT_IMAGE_VERSION}
+    build: ./reports
     user: "${RUNNER_USER_ID}:${RUNNER_GROUP_ID}"
     depends_on:
       - influxdb
@@ -195,19 +195,19 @@ services:
       - INFLUXDB_HOST=${INFLUXDB_HOST}
       - INFLUXDB_PORT=${INFLUXDB_PORT}
       - EXIT_CODE_FAIL=${EXIT_CODE_FAIL}
+      - REPORT_FORMAT="xml"
     volumes:
       - ./reports/reports:/opt/report/results/:rw
       - ./input/urls.yaml:/opt/report/urls.yaml:ro
       - ./yellowLabTools/reports:/opt/report/offenders:ro
     profiles:
       - report
-    networks: 
-     - pagiel
+    networks:
+      - pagiel
 
 networks:
   pagiel:
     name: "pagiel"
-
 
 volumes:
   influxdb-storage:

--- a/pagiel.sh
+++ b/pagiel.sh
@@ -3,7 +3,7 @@
 docker_compose_cmd=${DOCKER_COMPOSE_CMD:-docker compose}
 docker_compose_options=${DOCKER_COMPOSE_OPTIONS}
 docker_compose_pagiel="$docker_compose_cmd $docker_compose_options"
-
+exportFormat="xml" 
 
 # function
 
@@ -146,9 +146,8 @@ testsrobot() {
 }
 
 makeReport() {
-    # Démarrage du conteneur de génération de raport
-    echo "Start report generation"
-    ${docker_compose_pagiel} run --rm report
+    # Démarrage du conteneur de génération de rapport
+    ${docker_compose_pagiel} run --rm -e REPORT_FORMAT=excel report
     errCode=$?
     if [ $errCode -ne 0 ];
     then
@@ -212,6 +211,7 @@ while [[ $# > 0 ]]; do
       -d) dockerMode=image;;
       -D) dockerMode=compose;;
       --docker-image) dockerImage=$2 && shift;;
+      --export-format) exportFormat=$2 && shift;;
       --docker-port) dockerPort=$2 && shift;;
       --docker-front-container) dockerContainerName=$2 && shift;;
       --docker-compose-file) dockerComposeFile=$2 && shift;;
@@ -222,6 +222,9 @@ while [[ $# > 0 ]]; do
    shift
 done
 
+if [ "$exportFormat" = "csv" ] ; then
+    exportFormat="csv"
+fi
 if [ "$doPowerAPI" = true ] ; then
     startPowerAPI
 fi
@@ -251,10 +254,10 @@ fi
 
 if [ "$doRobotFramework" = true ] ; then
     startSelenium
+    sleep 1 # selenium needs 1s before robotframework can query it
     testsrobot
 fi
 
 if [ "$doReport" = true ] ; then
     makeReport
 fi
-

--- a/reports/src/reportGenerator/__init__.py
+++ b/reports/src/reportGenerator/__init__.py
@@ -1,8 +1,13 @@
 from typing import Any, Dict
 from xml.etree.cElementTree import SubElement, Element, ElementTree
 from json import load as loadJson
+import csv
 from datetime import datetime
 from collections import defaultdict
+from os import environ
+import argparse
+import shutil
+import os
 
 from yaml import load as yamlload, FullLoader
 
@@ -185,17 +190,33 @@ class JunitReportGenerator:
         testsuites.set("tests", str(total_tests))
         testsuites.set("failures", str(total_failure))
         return ElementTree(testsuites)
+    def export_to_csv(self, comparison_results: dict, output_file: str, timestamp: int):
+        with open(output_file, 'w', newline='') as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(['Test Name', 'Category', 'Indicator', 'Comparison', 'Expected', 'Value', 'Offenders', 'Result'])
+            for test_name, test_results in comparison_results.items():
+                for category_name, category_results in test_results.items():
+                    for indicator, indic_results in category_results.items():
+                        for comparison, result in indic_results.items():
+                            row = [test_name, category_name, indicator, comparison, result['expected'], result['value'], result.get('path', ''), result['result']]
+                            writer.writerow(row)
+        dst_file = f'/opt/report/results/report-{timestamp}.csv'
+        shutil.copy(output_file, dst_file)
+        print(f"Exported results to {output_file} in CSV format.")
 
 def main(influxdb_client: InfluxClient, indicators_by_category: dict, offenders: list) -> bool:
     url_list = load_yaml_data_file("/opt/report/urls.yaml")
     indicator_comparator = IndicatorComparator(influxdb_client, indicators_by_category)
     comparison_results = indicator_comparator.test_url_list(url_list)
-
     if len(comparison_results) > 0:
         timestamp = int(datetime.now().timestamp())
-
         junit_generator = JunitReportGenerator(offenders)
-        result_xml = junit_generator.generate_testsuites_xml(comparison_results)
-        result_xml.write("/opt/report/results/report.xml")
-        result_xml.write(f"/opt/report/results/report-{timestamp}.xml")
+        if(environ["REPORT_FORMAT"] == "csv"):    
+            result_csv = junit_generator.export_to_csv(comparison_results,"/opt/report/results/report.csv",timestamp)
+        else:
+            result_xml = junit_generator.generate_testsuites_xml(comparison_results)
+            result_xml.write("/opt/report/results/report.xml")
+            print("test results written to /opt/report/results/report.xml")
+            result_xml.write(f"/opt/report/results/report-{timestamp}.xml")
+            
     return indicator_comparator.some_failed


### PR DESCRIPTION
## ❌ Problème

- Les résultats sont exportés en une seule format XML.
## 🎁 Proposition

Ajouter la fonctionnalité d'exporter les résultats en csv : 

- Implémenter une fonction export-to-csv dans reports/src/reportGenerator/__init__.py.
- Ajouter une variable d'environnement au service report dans docker-compose.yml.
- Ajouter une option dans pagiel.sh: --export-format pour spécifier le format des rapports de résultats.

## 🌈 Remarques
Si l'option --export-format n'est pas renseignée, les rapports sont exportés en xml par défaut.
## 💯 Pour tester
````
docker compose run --build -e REPORT_FORMAT=xml report
````
ou bien avec pagiel.sh
````
./pagiel.sh --export-format csv
````
